### PR TITLE
[customers-show/edit/unsubscribe]Nagano-cake

### DIFF
--- a/app/assets/stylesheets/public/customers.scss
+++ b/app/assets/stylesheets/public/customers.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the public/customers controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -1,0 +1,32 @@
+class Public::CustomersController < ApplicationController
+
+
+  def show
+    @customer = current_customer
+  end
+
+  def edit
+    @customer = current_customer
+  end
+
+  def update
+    @customer = current_customer
+    if @customer.update
+      redirect_to my_page_path
+    else
+      render :edit
+    end
+  end
+
+  def unsubscribe
+    @customer = current_customer
+  end
+
+  def withdraw
+    @customer = current_customer
+    @customer.update(is_deleted: true)
+    reset_session
+    redirect_to root_path
+  end
+
+end

--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -26,13 +26,14 @@ class Public::SessionsController < Devise::SessionsController
     ## アカウントを取得できなかった場合、このメソッドを終了する
     return if !@customer
     ## 【処理内容2】 取得したアカウントのパスワードと入力されたパスワードが一致してるかを判別
-    if @customer.valid_password?(params[:customer][:password])
+    if @customer.valid_password?(params[:customer][:password]) && (@customer.is_deleted == true)
     ## 【処理内容3】
       redirect_to new_customer_registration_path
     else
       render :create
     end
   end
+
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params

--- a/app/helpers/public/customers_helper.rb
+++ b/app/helpers/public/customers_helper.rb
@@ -1,0 +1,2 @@
+module Public::CustomersHelper
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -3,4 +3,9 @@ class Customer < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+
+  def active_for_authentication?
+    super && (is_deleted == false)
+  end
 end

--- a/app/views/public/customers/edit.html.erb
+++ b/app/views/public/customers/edit.html.erb
@@ -1,0 +1,1 @@
+<h1>customer/edit</h1>

--- a/app/views/public/customers/show.html.erb
+++ b/app/views/public/customers/show.html.erb
@@ -1,0 +1,1 @@
+<h1>customer/show</h1>

--- a/app/views/public/customers/unsubscribe.html.erb
+++ b/app/views/public/customers/unsubscribe.html.erb
@@ -1,0 +1,1 @@
+<h1>customer/unsubscribe</h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,18 @@
 Rails.application.routes.draw do
-  
+
 
   scope module: 'public' do
     root to: 'homes#top'
     get 'about' => 'homes#about', as: 'about'
+
+    #customers [show.edit.update.unsubscribe.withdraw]
+    get 'customers/my_page' => 'customers#show', as: 'my_page'
+    get 'customers/infomation/edit' => 'customers#edit', as: 'my_page_edit'
+    patch 'customers/infomation' => 'customers#update'
+    get 'customers/unsubscribe' => 'customers#unsubscribe', as: 'unsubscribe'
+    patch 'customers/withdraw' => 'customers#withdraw'
+
+
   end
 
 

--- a/test/controllers/public/customers_controller_test.rb
+++ b/test/controllers/public/customers_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Public::CustomersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
public/customersの生成（詳細は以下に記載）
・show,edit,unsubscribeページの作成
・update,withdrawアクションの作成
・routesの編集、URLをアプリケーション詳細設計書の通りに命名
・退会済みのユーザーが同じアカウントでログイン出来ないよう編集
